### PR TITLE
fix: fix "InvalidImageName" error

### DIFF
--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -17,6 +17,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: {{ .Release.Name }}
+              # If we leave registry empty, then there will be an excess slash(/) in front of the repository, which will cause "InvalidImageName" error
               {{- if .Values.image.registry }}
               image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
               {{- else }}

--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -17,7 +17,11 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: {{ .Release.Name }}
+              {{- if .Values.image.registry }}
               image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
+              {{- else }}
+              image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+              {{- end }}
               resources:
                 limits:
                   cpu: {{ .Values.resources.limits.cpu }}


### PR DESCRIPTION
The "InvalidImageName" error occurs when trying to deploy a local backupper with an empty registry. If we leave registry empty, then there will be an excess slash(/) in front of the repository